### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches: [ develop, main, 'feature/*', 'release/*', 'hotfix/*' ]
   pull_request:
 
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,8 @@ on:
     branches: [ develop, main, 'feature/*', 'release/*', 'hotfix/*' ]
   pull_request:
 
+permissions:
+  contents: read
 
 jobs:
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main, 'release/*' ]
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     branches: [ develop, main, 'feature/*', 'release/*', 'hotfix/*' ]
   pull_request:
 
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/sm-moshi/ai-memory-cli/security/code-scanning/1](https://github.com/sm-moshi/ai-memory-cli/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the required permissions. Since the workflow creates a release using the `softprops/action-gh-release@v2` action, it needs `contents: write` permission. For all other operations, `contents: read` is sufficient. Adding this block ensures that the workflow adheres to the principle of least privilege.

The `permissions` block will be added at the root level of the workflow, applying to all jobs. This is appropriate because the workflow has only one job (`release`), and the permissions required are specific to the workflow's purpose.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
